### PR TITLE
No line breaks on long underlined links

### DIFF
--- a/resume-openfont.cls
+++ b/resume-openfont.cls
@@ -129,7 +129,7 @@
 
 % Underlined link command
 \newcommand{\underlinedLink}[2]{%
-\uline{\href{#1}{#2}}%
+\href{#1}{\uline{#2}}%
 }
 
 % Command for table 


### PR DESCRIPTION
When using the command `\underlinedLink`, `\uline` does not cause a line break when the text is very large. Moving the `\uline` inside the second parameter of `\href` solves the issue. 

Before:

![example](https://user-images.githubusercontent.com/3302518/154257641-6e872205-40e0-4636-82a2-ef4e03b36a9e.png)

After the fix:

![example-fix](https://user-images.githubusercontent.com/3302518/154257858-fa863442-285d-4866-9d6a-a45fad633528.png)

